### PR TITLE
Bf02 arrumar bug da edicao de usuario

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -51,11 +51,10 @@ class UserSerializer(serializers.ModelSerializer):
 
 
     def update(self, instance, validated_data):
-        id = instance.id
-        instance = User(**validated_data)
-        instance.id = id
+        updated = User(**validated_data)
+        updated.id = instance.id
         password = validated_data['password']
-        instance.set_password(password)
+        updated.set_password(password)
         return instance
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -51,11 +51,24 @@ class UserSerializer(serializers.ModelSerializer):
 
 
     def update(self, instance, validated_data):
-        updated = User(**validated_data)
-        updated.id = instance.id
-        password = validated_data['password']
-        updated.set_password(password)
-        return instance
+        updatedUser = vars(instance)
+        del(updatedUser['_state'])
+        print('\n\n\n\n{}\n\n\n\n'.format(updatedUser))
+        for field, value in validated_data.items():
+            updatedUser[field] = value
+        print('\n\n\n\n{}\n\n\n\n'.format(updatedUser))
+        updated = User(**updatedUser)
+        if 'password' in validated_data:
+            updated.set_password(validated_data['password'])
+        
+        return updated
+        # updated = User(**validated_data)
+        # toptop = vars(updated)
+        # print('\n\n\n\n{}\n\n\n\n'.format(toptop))
+        # updated.id = instance.id
+        # password = validated_data['password']
+        # updated.set_password(password)
+        # return instance
 
 
 class ParliamentarySerializer(serializers.ModelSerializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -51,9 +51,11 @@ class UserSerializer(serializers.ModelSerializer):
 
 
     def update(self, instance, validated_data):
+        id = instance.id
         instance = User(**validated_data)
+        instance.id = id
         password = validated_data['password']
-        instance.set_password(password) 
+        instance.set_password(password)
         return instance
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -57,7 +57,7 @@ class UserSerializer(serializers.ModelSerializer):
         updated = User(**updatedUser)
         if 'password' in validated_data:
             updated.set_password(validated_data['password'])
-
+        updated.save()
         return updated
 
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -50,6 +50,13 @@ class UserSerializer(serializers.ModelSerializer):
         return voxpopuser
 
 
+    def update(self, instance, validated_data):
+        instance = User(**validated_data)
+        password = validated_data['password']
+        instance.set_password(password) 
+        return instance
+
+
 class ParliamentarySerializer(serializers.ModelSerializer):
     class Meta:
         model = Parliamentary

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -49,26 +49,16 @@ class UserSerializer(serializers.ModelSerializer):
         token.save()
         return voxpopuser
 
-
     def update(self, instance, validated_data):
         updatedUser = vars(instance)
         del(updatedUser['_state'])
-        print('\n\n\n\n{}\n\n\n\n'.format(updatedUser))
         for field, value in validated_data.items():
             updatedUser[field] = value
-        print('\n\n\n\n{}\n\n\n\n'.format(updatedUser))
         updated = User(**updatedUser)
         if 'password' in validated_data:
             updated.set_password(validated_data['password'])
-        
+
         return updated
-        # updated = User(**validated_data)
-        # toptop = vars(updated)
-        # print('\n\n\n\n{}\n\n\n\n'.format(toptop))
-        # updated.id = instance.id
-        # password = validated_data['password']
-        # updated.set_password(password)
-        # return instance
 
 
 class ParliamentarySerializer(serializers.ModelSerializer):

--- a/api/tests.py
+++ b/api/tests.py
@@ -66,17 +66,16 @@ class UserTests(APITestCase):
         """
         self.assertEqual(self.user.username, 'teste')
         data = {
-            'username':'updated',
-            'first_name':'teste',
+            'username':'teste',
+            'first_name':'updated',
             'last_name':'teste',
             'email':'teste@teste.com',
             'password':'teste'
         }
         response = self.client.put(self.url + str(self.user.pk) + '/', data)
-
         new_user = User.objects.get(pk=self.user.pk)
         self.assertEqual(response.status_code,  status.HTTP_200_OK)
-        self.assertEqual(new_user.username, 'updated')
+        self.assertEqual(new_user.first_name, data['first_name'])
 
     def test_invalid_update_user(self):
         """


### PR DESCRIPTION
# BF02 - Arrumar bug da edição de usuário
<!-- O que este pull request adiciona ao projeto? O que foi alterado?-->
## Descrição 
As chamadas de `put` e `patch` alteravam a senha do usuário sem criptografia, fazendo com que o usuário fosse impossibilitado de logar no sistema.
Através de uma sobrescrita do método `update`, a edição da senha recriptografa a entrada do usuário, consertando o problema descrito.

<!-- Onde encontro a documentação da issue?-->
<!-- Ex: [Test Issue](https://github.com/fga-gpp-mds/2018.1-VoxPop-WebApp/issues/1)-->
[BF02 - Arrumar bug da edição de usuário](https://github.com/fga-gpp-mds/2018.1-VoxPop-API/issues/60) 

resolve #60
